### PR TITLE
disable installing dev tools by default

### DIFF
--- a/install/applications.sh
+++ b/install/applications.sh
@@ -1,7 +1,7 @@
 cd ~
 
 # install developer tools
-xcode-select --install
+# xcode-select --install (i think that macos prompts you for this when you run git)
 
 # install homebrew
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"


### PR DESCRIPTION
macos prompted me to install them when i tried to use git to clone this repo.

this is also relevant:
https://stackoverflow.com/questions/15371925/how-to-check-if-command-line-tools-is-installed