### PR TITLE
add support for running in work-machine-only mode

### DIFF
--- a/install/applications-work.sh
+++ b/install/applications-work.sh
@@ -1,0 +1,25 @@
+# work maching specific applications
+
+cd ~
+
+brew install gcc
+
+brew install --cask adoptopenjdk8
+brew install --cask intellij-idea-ce
+
+brew tap mdogan/zulu
+brew info zulu-jdk8
+
+brew install jq
+brew install maven
+brew install hashicorp/tap/terraform
+brew install python
+brew install travis
+brew install pyenv
+brew install golangci-lint
+brew install gnu-sed
+brew install findutils
+brew install less
+
+# ibmcloud cli tool
+curl -fsSL https://clis.cloud.ibm.com/install/osx | sh

--- a/install/applications.sh
+++ b/install/applications.sh
@@ -23,31 +23,6 @@ brew install z
 brew install git-delta
 brew install duti
 
-## work specific
-# ?? idk where this is coming from but it was run
-# on my current machine right when i got it
-brew install gcc
-
-brew install --cask adoptopenjdk8
-brew install --cask intellij-idea-ce
-
-brew tap mdogan/zulu
-brew info zulu-jdk8
-
-brew install jq
-brew install maven
-brew install hashicorp/tap/terraform
-brew install python
-brew install travis
-brew install pyenv
-brew install golangci-lint
-brew install gnu-sed
-brew install findutils
-brew install less
-
-## work specific - ibmcloud cli tool
-curl -fsSL https://clis.cloud.ibm.com/install/osx | sh
-
 # install zprezto
 git clone --recursive https://github.com/sorin-ionescu/prezto.git "${ZDOTDIR:-$HOME}/.zprezto"
 

--- a/install/applications.sh
+++ b/install/applications.sh
@@ -10,10 +10,6 @@ cd ~
 # true for apple silicon machines
 eval "$(/opt/homebrew/bin/brew shellenv)"
 
-# ?? idk where this is coming from but it was run
-# on my current machine right when i got it
-brew install gcc
-
 # install applications available with brew
 brew install --cask rectangle
 brew install --cask spotify
@@ -24,12 +20,21 @@ brew install --cask spotmenu
 
 brew install golang
 brew install z
-brew install jq
 brew install git-delta
 brew install duti
 
 ## work specific
+# ?? idk where this is coming from but it was run
+# on my current machine right when i got it
+brew install gcc
+
 brew install --cask adoptopenjdk8
+brew install --cask intellij-idea-ce
+
+brew tap mdogan/zulu
+brew info zulu-jdk8
+
+brew install jq
 brew install maven
 brew install hashicorp/tap/terraform
 brew install python

--- a/setup-new-machine.sh
+++ b/setup-new-machine.sh
@@ -4,6 +4,11 @@
 # install applications
 ./install/applications.sh
 
+# install work-only apps
+if [[ $1 == "work" ]]; then
+  ./install/applications-work.sh
+fi
+
 # link configuration and settings files
 ./setup/link-files.sh
 
@@ -15,8 +20,10 @@ duti ~/.config/duti/defaults.duti
 
 ./install/post-link-applications.sh
 
-# install node and npm modules
+# install node
 ./install/node.sh
 
-## make this work only
-./install/npm-modules.sh
+# pre-install npm modules on work machine only
+if [[ $1 == "work" ]]; then
+  ./install/npm-modules.sh
+fi

--- a/setup-new-machine.sh
+++ b/setup-new-machine.sh
@@ -10,11 +10,13 @@
 # refresh profile
 . ~/.zshrc
 
-./install/post-link-applications.sh
-
 # execute duti
 duti ~/.config/duti/defaults.duti
 
+./install/post-link-applications.sh
+
 # install node and npm modules
 ./install/node.sh
+
+## make this work only
 ./install/npm-modules.sh

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -15,13 +15,11 @@ source "$(brew --prefix)/etc/profile.d/z.sh"
 
 export GOPATH=$HOME/go
 export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
-# export PATH=/Users/dustinpopp/Library/Python/3.9/bin:/usr/local/opt/python/libexec/bin:$PATH
 
 export N_PREFIX=~/n
 export PATH=~/npm-global/bin:$PATH
 export PATH=~/n/bin:$PATH
 
-# export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
 export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_311.jdk/Contents/Home
 
 # added by travis gem


### PR DESCRIPTION
Main script now takes an argument. Passing "work" as the arg will run in work-machine mode, which right now only include extras (its a superset of the functionality in personal mode). Personal mode by default.